### PR TITLE
Add test watcher

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,7 +16,7 @@
 	// Add the IDs of extensions you want installed when the container is created.
 	"extensions": [
 		"dbaeumer.vscode-eslint",
-		"JuanBlanco.solidity",
+		"NomicFoundation.hardhat-solidity",
 		"esbenp.prettier-vscode"
 	],
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Includes:
 
 -   configuration for deploying to any EVM chain
 -   suite of tests
-    -   run tests locally (via `npm test`)
+    -   run tests locally with watcher (via `npm test`)
     -   use [Chai matchers from Waffle](https://ethereum-waffle.readthedocs.io/en/latest/matchers.html) (instead of OpenZeppelin Test Helpers)
     -   includes Github Action to run tests
     -   run gas report

--- a/contract/.gitignore
+++ b/contract/.gitignore
@@ -5,3 +5,4 @@ cache
 typechain-types
 coverage
 coverage.json
+unknown-31337.json

--- a/contract/hardhat.config.ts
+++ b/contract/hardhat.config.ts
@@ -38,7 +38,7 @@ const config: HardhatUserConfig = {
         enabled: process.env.REPORT_GAS ? true : false,
     },
     watcher: {
-        compilation: {
+        test: {
             tasks: ['test'],
         },
     },

--- a/contract/package.json
+++ b/contract/package.json
@@ -4,7 +4,7 @@
     "description": "",
     "main": "index.js",
     "scripts": {
-        "test": "hardhat watch compilation --network hardhat",
+        "test": "hardhat watch test --network hardhat",
         "test:ci": "hardhat test --network hardhat test/*.ts",
         "test:gas": "REPORT_GAS=1 hardhat test --network hardhat test/*.ts",
         "test:coverage": "hardhat coverage --network hardhat",


### PR DESCRIPTION
- add test watcher
- switch to Hardhat's Solidity plugin for VSCode
- Ignore openzeppelin upgrade files generated from tests